### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   # sudo apt-get update (enable once apt-get is used)
 
   # install (mini)conda if not cached
-  - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron"]; then
+  - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron" ]; then
       conda_cached=false;
       rm -rf $HOME/miniconda;
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
   # sudo apt-get update (enable once apt-get is used)
 
   # install (mini)conda if not cached
-  - echo $TRAVIS_EVENT_TYPE
   - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron"]; then
       conda_cached=false;
       rm -rf $HOME/miniconda;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 
   # install (mini)conda if not cached
   - echo $TRAVIS_EVENT_TYPE
-  - if [ ! -d $HOME/miniconda/bin/ ]; then
+  - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron"]; then
       conda_cached=false;
       rm -rf $HOME/miniconda;
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   # sudo apt-get update (enable once apt-get is used)
 
   # install (mini)conda if not cached
+  - echo $TRAVIS_EVENT_TYPE
   - if [ ! -d $HOME/miniconda/bin/ ]; then
       conda_cached=false;
       rm -rf $HOME/miniconda;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   # sudo apt-get update (enable once apt-get is used)
 
   # install (mini)conda if not cached
-  - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron" ]; then
+  - if [[ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ cron ]]; then
       echo "no cache, or a cron job";
       conda_cached=false;
       rm -rf $HOME/miniconda;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 
   # install (mini)conda if not cached
   - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron" ]; then
-      echo "no cache, or a cron job"
+      echo "no cache, or a cron job";
       conda_cached=false;
       rm -rf $HOME/miniconda;
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 
   # install (mini)conda if not cached
   - if [ ! -d $HOME/miniconda/bin/ || $TRAVIS_EVENT_TYPE =~ "cron" ]; then
+      echo "no cache, or a cron job"
       conda_cached=false;
       rm -rf $HOME/miniconda;
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
To speedup the travis tests, the conda environment is cached. Now the cache gets deleted weekly, to periodically check if the environment is still valid.

**What did change**
Added a cron job to travis to weekly run. When the travis build discovers it is a cron job, it will delete the cache folder, and makes a fresh one.

**Does this need additional test(s)?**
No