### PR TITLE
implemented count table #181

### DIFF
--- a/envs/bedtools.yaml
+++ b/envs/bedtools.yaml
@@ -1,0 +1,7 @@
+name: bedtools
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - bioconda::bedtools=2.29.0

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -375,7 +375,7 @@ rule samtools_index:
     input:
         expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam", **config)
     output:
-        expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bai", **config)
+        expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam.bai", **config)
     log:
         expand("{log_dir}/samtools_index/{{assembly}}-{{sample}}-{{sorter}}-{{sorting}}.log", **config)
     benchmark:

--- a/rules/assembly_hub.smk
+++ b/rules/assembly_hub.smk
@@ -28,7 +28,7 @@ rule bam_stranded_bigwig:
     """
     input:
         bam=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam", **config),
-        bai=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bai", **config)
+        bai=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam.bai", **config)
     output:
         forward=expand("{result_dir}/bigwigs/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.fwd.bw", **config),
         reverse=expand("{result_dir}/bigwigs/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.rev.bw", **config),
@@ -65,7 +65,7 @@ rule bam_bigwig:
     """
     input:
         bam=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam", **config),
-        bai=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bai", **config)
+        bai=expand("{dedup_dir}/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bam.bai", **config)
     output:
         expand("{result_dir}/bigwigs/{{assembly}}-{{sample}}.{{sorter}}-{{sorting}}.bw", **config)
     params:

--- a/rules/call_peak.smk
+++ b/rules/call_peak.smk
@@ -41,7 +41,7 @@ rule call_peak_genrich:
     input:
         log=expand("{result_dir}/genrich/{{fname}}.log", **config)
     output:
-        narrowpeak= expand("{result_dir}/genrich/{{fname}}_peaks.narrowPeak", **config)
+        narrowpeak=expand("{result_dir}/genrich/{{fname}}_peaks.narrowPeak", **config)
     log:
         expand("{log_dir}/call_peak_genrich/{{fname}}_peak.log", **config)
     benchmark:

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -36,6 +36,14 @@ if config.get('peak_caller', False):
         assert all([config['layout'][sample] == 'PAIRED' for sample in samples.index]), \
         "HMMRATAC requires all samples to be paired end"
 
+    # collect which sorting we use
+    config['bam_sortings'] = []
+    if any([peak_caller in ['idr', 'macs2'] for peak_caller in config['peak_caller'].keys()]):
+        config['bam_sortings'].append('samtools-coordinate')
+    if any([peak_caller in ['genrich'] for peak_caller in config['peak_caller'].keys()]):
+        config['bam_sortings'].append('sambamba-queryname')
+
+
 # for alignment and rna-seq
 for conf_dict in ['aligner', 'diffexp']:
     if config.get(conf_dict, False):
@@ -275,7 +283,7 @@ def add_default_resources(func):
 
 
 # now add the wrapper to the workflow execute function
-workflow.execute = add_default_resources(workflow.execute)
+# workflow.execute = add_default_resources(workflow.execute)
 
 
 # functional but currently unused

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -283,7 +283,7 @@ def add_default_resources(func):
 
 
 # now add the wrapper to the workflow execute function
-# workflow.execute = add_default_resources(workflow.execute)
+workflow.execute = add_default_resources(workflow.execute)
 
 
 # functional but currently unused

--- a/rules/peak_count.smk
+++ b/rules/peak_count.smk
@@ -1,0 +1,57 @@
+def get_peak_replicates(wildcards):
+    if 'condition' in samples and config.get('condition', False):
+        # if we have conditions use those peaks
+        return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{condition}_peaks.narrowPeak"
+            for condition in set(samples[samples['assembly'] == wildcards.assembly]['condition'])], **config)
+    # otherwise all the separate ones
+    return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}_peaks.narrowPeak"
+        for replicate in samples[samples['assembly'] == wildcards.assembly].index], **config)
+
+
+rule peak_union:
+    input:
+        get_peak_replicates
+    output:
+        expand("{result_dir}/{{peak_caller}}/{{assembly}}_peaks.bed", **config)
+    log:
+        expand("{log_dir}/peak_union/{{assembly}}-{{peak_caller}}.log", **config)
+    benchmark:
+        expand("{log_dir}/peak_union/{{assembly}}-{{peak_caller}}.benchmark.txt", **config)[0]
+    conda:
+        "../envs/bedtools.yaml"
+    shell:
+        "cat {input} | sort -k1,1 -k2,2n | mergeBed -i stdin > {output}"
+
+
+def get_multicov_replicates(file_ext):
+    def wrapped(wildcards):
+        if 'condition' in samples and config.get('condition', '') == 'merge':
+            # if replicates' fastqs are merged get the merged bam
+            return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
+                for replicate in set(samples[samples['assembly'] == wildcards.assembly]['condition'])], **config)
+        # otherwise all the separate ones
+        return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
+            for replicate in samples[samples['assembly'] == wildcards.assembly].index], **config)
+    return wrapped
+
+
+rule multicov:
+    input:
+        peaks=rules.peak_union.output,
+        replicates=get_multicov_replicates('bam'),
+        replicate_bai=get_multicov_replicates('bam.bai')
+    output:
+        expand("{result_dir}/count_table/{{peak_caller}}/count_table_{{assembly}}.{{sorter}}-{{sorting}}.bed", **config)
+    log:
+        expand("{log_dir}/multicov/{{assembly}}-{{peak_caller}}-{{sorter}}-{{sorting}}.log", **config)
+    benchmark:
+        expand("{log_dir}/multicov/{{assembly}}-{{peak_caller}}-{{sorter}}-{{sorting}}.benchmark.txt", **config)[0]
+    conda:
+        "../envs/bedtools.yaml"
+    params:
+        files=lambda wildcards, input: "\\t".join([file.split('-')[-2].split('.')[0] for file in input.replicates])
+    shell:
+        """
+        echo -e "QNAME\\tstart\\tend\\t{params.files}" > {output}
+        bedtools multicov -bams {input.replicates} -bed {input.peaks} >> {output}
+        """

--- a/rules/peak_count.smk
+++ b/rules/peak_count.smk
@@ -1,10 +1,10 @@
 def get_peak_replicates(wildcards):
-    if 'condition' in samples and config.get('condition', False):
+    if 'condition' in samples and config.get('combine_replicates', False):
         # if we have conditions use those peaks
-        return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{condition}_peaks.narrowPeak"
+        return expand([f"{{result_dir}}/{wildcards.peak_caller}/{wildcards.assembly}-{condition}_peaks.narrowPeak"
             for condition in set(samples[samples['assembly'] == wildcards.assembly]['condition'])], **config)
     # otherwise all the separate ones
-    return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}_peaks.narrowPeak"
+    return expand([f"{{result_dir}}/{wildcards.peak_caller}/{wildcards.assembly}-{replicate}_peaks.narrowPeak"
         for replicate in samples[samples['assembly'] == wildcards.assembly].index], **config)
 
 
@@ -25,7 +25,7 @@ rule peak_union:
 
 def get_multicov_replicates(file_ext):
     def wrapped(wildcards):
-        if 'condition' in samples and config.get('condition', '') == 'merge':
+        if 'condition' in samples and config.get('combine_replicates', '') == 'merge':
             # if replicates' fastqs are merged get the merged bam
             return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
                 for replicate in set(samples[samples['assembly'] == wildcards.assembly]['condition'])], **config)

--- a/workflows/alignment/Snakefile
+++ b/workflows/alignment/Snakefile
@@ -25,5 +25,5 @@ rule align_all:
     """
     input:
         [expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam", **config) for sample in samples.index],
-        [expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bai", **config) for sample in samples.index if config['bam_sort_order'] == 'coordinate'],
+        [expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam.bai", **config) for sample in samples.index if config['bam_sort_order'] == 'coordinate'],
          expand("{qc_dir}/multiqc_{assemblies}.html", **{**config, **{'assemblies': set(samples['assembly'])}})

--- a/workflows/atac_seq/Snakefile
+++ b/workflows/atac_seq/Snakefile
@@ -14,6 +14,7 @@ include: f"{config['rule_dir']}/call_peak.smk"
 include: f"{config['rule_dir']}/get_genome.smk"
 include: f"{config['rule_dir']}/get_fastq.smk"
 include: f"{config['rule_dir']}/merge_replicates.smk"
+include: f"{config['rule_dir']}/peak_count.smk"
 include: f"{config['rule_dir']}/qc.smk"
 include: f"{config['rule_dir']}/trackhub.smk"
 include: f"{config['rule_dir']}/trimming.smk"
@@ -28,4 +29,8 @@ rule call_peaks_all:
     """
     input:
          expand("{result_dir}/trackhub", **config),
-         expand("{qc_dir}/multiqc_{assemblies}.html", **{**config, **{'assemblies': set(samples['assembly'])}})
+         # expand("{qc_dir}/multiqc_{assemblies}.html", **{**config, **{'assemblies': set(samples['assembly'])}})
+         expand(["{result_dir}/count_table/{peak_caller}/count_table_{assemblies}.{bam_sortings}.bed",
+                 "{qc_dir}/multiqc_{assemblies}.html"],
+                **{**config,
+                   **{'assemblies': set(samples['assembly']), 'peak_caller': config['peak_caller'].keys()}})

--- a/workflows/atac_seq/Snakefile
+++ b/workflows/atac_seq/Snakefile
@@ -29,7 +29,6 @@ rule call_peaks_all:
     """
     input:
          expand("{result_dir}/trackhub", **config),
-         # expand("{qc_dir}/multiqc_{assemblies}.html", **{**config, **{'assemblies': set(samples['assembly'])}})
          expand(["{result_dir}/count_table/{peak_caller}/count_table_{assemblies}.{bam_sortings}.bed",
                  "{qc_dir}/multiqc_{assemblies}.html"],
                 **{**config,


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Make a simple count table for each peak, for further downstream analysis:
```
QNAME   start   end     GSM2837488      GSM2837489
FLLO01000001.1  100807  101247  153     64
FLLO01000001.1  433814  434214  336     864
FLLO01000001.1  987378  987867  572     114
FLLO01000001.1  987959  988938  2503    1400
FLLO01000001.1  1567413 1567833 116     669
```

**What did change**
Of all peaks a union is taken, and the number of counts under this union is taken for each sample.

**Does this need additional test(s)?**
Yes, not sure if it works with all conditions (e.g. merge, fisher, etc.)