### PR TITLE
Added insert sizes to multiqc report

### DIFF
--- a/envs/picard.yaml
+++ b/envs/picard.yaml
@@ -1,7 +1,7 @@
 name: picard
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
-  - bioconda::picard=2.9.2
+  - bioconda::picard=2.21.2

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -15,7 +15,6 @@ def get_alignment_pipes():
     else:
         pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.{bam_sorter}-{bam_sort_order}.pipe", **config)[0]))
 
-    print(pipes)
     return pipes
 
 

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -11,10 +11,11 @@ def get_reads(wildcards):
 def get_alignment_pipes():
     pipes = {pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools-coordinate.pipe", **config)[0])}
     if config.get('peak_caller', False) and 'genrich' in config['peak_caller']:
-        pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba.pipe", **config)[0]))
+        pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba-queryname.pipe", **config)[0]))
     else:
         pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.{bam_sorter}-{bam_sort_order}.pipe", **config)[0]))
 
+    print(pipes)
     return pipes
 
 

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -9,14 +9,11 @@ def get_reads(wildcards):
         return sorted(expand("{trimmed_dir}/{{sample}}_{fqext}_trimmed.{fqsuffix}.gz", **config))
 
 def get_alignment_pipes():
-    pipes = set()
-    if config.get('peak_caller', False):
-        if 'macs2' in config['peak_caller'] or 'hmmratac' in config['peak_caller']:
-            pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools.pipe", **config)[0]))
-        if 'genrich' in config['peak_caller']:
-            pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba.pipe", **config)[0]))
+    pipes = {pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools-coordinate.pipe", **config)[0])}
+    if config.get('peak_caller', False) and 'genrich' in config['peak_caller']:
+        pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba.pipe", **config)[0]))
     else:
-        pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.{bam_sorter}.pipe", **config)[0]))
+        pipes.add(pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.{bam_sorter}-{bam_sort_order}.pipe", **config)[0]))
 
     return pipes
 
@@ -324,7 +321,7 @@ rule sambamba_sort:
     Sort the result of alignment with the sambamba sorter.
     """
     input:
-        expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba.pipe", **config)
+        expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba-{{sorting}}.pipe", **config)
     output:
         expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.sambamba-{{sorting}}.bam", **config)
     log:
@@ -349,7 +346,7 @@ rule samtools_sort:
     Sort the result of alignment with the samtools sorter.
     """
     input:
-        expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools.pipe", **config)
+        expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools-{{sorting}}.pipe", **config)
     output:
         expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools-{{sorting}}.bam", **config)
     log:

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -36,13 +36,6 @@ if config.get('peak_caller', False):
         assert all([config['layout'][sample] == 'PAIRED' for sample in samples.index]), \
         "HMMRATAC requires all samples to be paired end"
 
-    # collect which sorting we use
-    config['bam_sortings'] = []
-    if any([peak_caller in ['idr', 'macs2'] for peak_caller in config['peak_caller'].keys()]):
-        config['bam_sortings'].append('samtools-coordinate')
-    if any([peak_caller in ['genrich'] for peak_caller in config['peak_caller'].keys()]):
-        config['bam_sortings'].append('sambamba-queryname')
-
 
 # for alignment and rna-seq
 for conf_dict in ['aligner', 'diffexp']:

--- a/rules/peak_count.smk
+++ b/rules/peak_count.smk
@@ -27,10 +27,10 @@ def get_multicov_replicates(file_ext):
     def wrapped(wildcards):
         if 'condition' in samples and config.get('combine_replicates', '') == 'merge':
             # if replicates' fastqs are merged get the merged bam
-            return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
+            return expand([f"{{dedup_dir}}/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
                 for replicate in set(samples[samples['assembly'] == wildcards.assembly]['condition'])], **config)
         # otherwise all the separate ones
-        return expand([f"{{result_dir}}/dedup/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
+        return expand([f"{{dedup_dir}}/{wildcards.assembly}-{replicate}.{wildcards.sorter}-{wildcards.sorting}.{file_ext}"
             for replicate in samples[samples['assembly'] == wildcards.assembly].index], **config)
     return wrapped
 

--- a/workflows/alignment/Snakefile
+++ b/workflows/alignment/Snakefile
@@ -22,18 +22,23 @@ quality_control = [get_trimming_qc, get_alignment_qc]
 
 def get_bams():
     bamfiles = {}
-    bamfiles['bams'] = []; bamfiles['bais'] = []
+    bamfiles['bams'] = set(); bamfiles['bais'] = set()
 
     # get all the bams
     if config.get('combine_replicates', '') == 'merge' and 'condition' in samples:
         for condition in set(samples['condition']):
             for assembly in set(samples[samples['condition'] == condition]['assembly']):
-                bamfiles['bams'].extend(expand(f"{{dedup_dir}}/{assembly}-{condition}.{{bam_sorter}}-{{bam_sort_order}}.bam", **config))
-                if config['bam_sort_order'] == 'coordinate':
-                    bamfiles['bais'].extend(expand(f"{{dedup_dir}}/{assembly}-{condition}.{{bam_sorter}}-{{bam_sort_order}}.bam.bai", **config))
+                bamfiles['bams'].update(expand(f"{{dedup_dir}}/{assembly}-{condition}.{{bam_sorter}}-{{bam_sort_order}}.bam", **config)[0])
+                bamfiles['bais'].update(expand(f"{{dedup_dir}}/{assembly}-{condition}.{{bam_sorter}}-{{bam_sort_order}}.bam.bai", **config)[0])
+                # always output samtools-coordinate
+                bamfiles['bams'].update(expand(f"{{dedup_dir}}/{assembly}-{condition}.samtools-coordinate.bam", **config)[0])
+                bamfiles['bais'].update(expand(f"{{dedup_dir}}/{assembly}-{condition}.samtools-coordinate.bam.bai", **config)[0])
     else:
-        bamfiles['bams'] = [expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam", **config) for sample in samples.index]
-        bamfiles['bais'] = [expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam.bai", **config) for sample in samples.index if config['bam_sort_order'] == 'coordinate']
+        bamfiles['bams'].update(expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam", **config)[0] for sample in samples.index)
+        bamfiles['bais'].update(expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.{{bam_sorter}}-{{bam_sort_order}}.bam.bai", **config)[0] for sample in samples.index if config['bam_sort_order'] == 'coordinate')
+        # always output samtools-coordinate
+        bamfiles['bams'].update({expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.samtools-coordinate.bam", **config)[0] for sample in samples.index})
+        bamfiles['bais'].update({expand(f"{{dedup_dir}}/{samples.loc[sample]['assembly']}-{sample}.samtools-coordinate.bam.bai", **config)[0] for sample in samples.index if config['bam_sort_order'] == 'coordinate'})
 
     return bamfiles
 

--- a/workflows/atac_seq/Snakefile
+++ b/workflows/atac_seq/Snakefile
@@ -29,7 +29,7 @@ rule call_peaks_all:
     """
     input:
          expand("{result_dir}/trackhub", **config),
-         expand(["{result_dir}/count_table/{peak_caller}/count_table_{assemblies}.{bam_sortings}.bed",
+         expand(["{result_dir}/count_table/{peak_caller}/count_table_{assemblies}.samtools-coordinate.bed",
                  "{qc_dir}/multiqc_{assemblies}.html"],
                 **{**config,
                    **{'assemblies': set(samples['assembly']), 'peak_caller': config['peak_caller'].keys()}})


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
A simple check for overdigestion is to take a look at insert sizes of paired-end reads. This is now implemented and outputed in the multiqc

**What did change**
If alignment happens, and the reads are paired-end, `picard CollectInsertSizeMetrics` is called on the bam file:
![image](https://user-images.githubusercontent.com/15323399/68677105-c1372180-055b-11ea-81df-b7c5e189d5da.png)

I had some troubles with R inside of picard, changing the channel priority seemed to fix it :smile: 