### PR TITLE
Assembly name can now contain dash (-)

### DIFF
--- a/rules/call_peak.smk
+++ b/rules/call_peak.smk
@@ -1,5 +1,5 @@
 def get_genrich_replicates(wildcards):
-    assembly, sample_condition = wildcards.fname.split('-')
+    assembly, sample_condition = "-".join(wildcards.fname.split('-')[:-1]), wildcards.fname.split('-')[-1]
     if not 'condition' in samples.columns or config.get('combine_replicates', '') == 'merge' \
     or (sample_condition in samples.index and not sample_condition in samples['condition'].values):
         return expand(f"{{dedup_dir}}/{wildcards.fname}.sambamba-queryname.bam", **config)


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
When peak calling we infer the assembly name by splitting on a dash, this didn't work properly with assemblies that also contain a dash.