### PR TITLE
keep mates: mate does not have to be shifted

### DIFF
--- a/rules/call_peak.smk
+++ b/rules/call_peak.smk
@@ -131,11 +131,17 @@ rule keep_mates:
                 bam_in = pysam.AlignmentFile(input[0], "rb")
                 bam_out = pysam.AlignmentFile(output[0], "wb", template=bam_in)
                 for line in bam_in:
-                    if line.flag & second_in_pair:
-                        line.pos += line.template_length
+                    line.qname = line.qname + ('\\1' if line.flag & first_in_pair else '\\2')
                     line.next_reference_id = 0
                     line.next_reference_start = 0
-                    line.flag &= ~(paired + proper_pair + mate_unmapped + mate_reverse + first_in_pair + second_in_pair)
+                    line.flag &= ~(
+                                paired +
+                                proper_pair +
+                                mate_unmapped +
+                                mate_reverse +
+                                first_in_pair +
+                                second_in_pair
+                    )
 
                     bam_out.write(line)
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
I made a mistake when removing the paired-end data from a bam. 

**What did change**
Before I shifted the mate with its read length, which obviously does not make any sense.. I removed that part. Now all flags get removed that a read has a pair, and the name gets a \1 or \2 added depending on whether it is the first in pair or second in pair.