### PR TITLE
fix bug in get_genome

### DIFF
--- a/rules/get_genome.smk
+++ b/rules/get_genome.smk
@@ -37,7 +37,7 @@ rule get_genome:
     shell:
         """
         # turn off plugins and reset on exit. delete temp files on exit.
-        active_plugins=$(genomepy config show | grep -Po '(?<=- ).*' | paste -s -d, -)
+        active_plugins=$(genomepy config show | grep -Po '(?<=- ).*' | paste -s -d, -) || echo ""
         trap "genomepy plugin enable {{$active_plugins,}} >> {log} 2>&1; rm -f {params.temp}" EXIT
         genomepy plugin disable {{blacklist,bowtie2,bwa,star,gmap,hisat2,minimap2}} >> {log} 2>&1
         

--- a/rules/trackhub.smk
+++ b/rules/trackhub.smk
@@ -519,7 +519,7 @@ rule trackhub:
                 else:
                     genome = trackhub.Genome(assembly)
 
-                genomes_file.add_genome(assembly)
+                genomes_file.add_genome(genome)
 
                 # each trackdb is added to the genome
                 trackdb = trackhub.trackdb.TrackDb()

--- a/rules/trackhub.smk
+++ b/rules/trackhub.smk
@@ -505,11 +505,13 @@ rule trackhub:
             hub.add_genomes_file(genomes_file)
 
             for assembly in set(samples['assembly']):
+                assembly_no_patch = \
+                    [split for split in re.split(r"(.+)(?=\.p\d)", assembly) if split != ''][0]
                 # add each assembly to the genomes file
                 if any(assembly in twobit for twobit in input.twobits):
                     basename = f"{config['genome_dir']}/{assembly}/{assembly}"
                     genome = trackhub.Assembly(
-                        genome=assembly,
+                        genome=assembly_no_patch,
                         twobit_file=basename + '.2bit',
                         organism=assembly,
                         defaultPos=get_defaultPos(basename + '.fa.sizes'),
@@ -519,7 +521,7 @@ rule trackhub:
                 else:
                     genome = trackhub.Genome(assembly)
 
-                genomes_file.add_genome(genome)
+                genomes_file.add_genome(assembly_no_patch)
 
                 # each trackdb is added to the genome
                 trackdb = trackhub.trackdb.TrackDb()

--- a/rules/trackhub.smk
+++ b/rules/trackhub.smk
@@ -505,13 +505,11 @@ rule trackhub:
             hub.add_genomes_file(genomes_file)
 
             for assembly in set(samples['assembly']):
-                assembly_no_patch = \
-                    [split for split in re.split(r"(.+)(?=\.p\d)", assembly) if split != ''][0]
                 # add each assembly to the genomes file
                 if any(assembly in twobit for twobit in input.twobits):
                     basename = f"{config['genome_dir']}/{assembly}/{assembly}"
                     genome = trackhub.Assembly(
-                        genome=assembly_no_patch,
+                        genome=assembly,
                         twobit_file=basename + '.2bit',
                         organism=assembly,
                         defaultPos=get_defaultPos(basename + '.fa.sizes'),
@@ -521,7 +519,7 @@ rule trackhub:
                 else:
                     genome = trackhub.Genome(assembly)
 
-                genomes_file.add_genome(assembly_no_patch)
+                genomes_file.add_genome(assembly)
 
                 # each trackdb is added to the genome
                 trackdb = trackhub.trackdb.TrackDb()


### PR DESCRIPTION
The way we now parse genomepy config assumes there is at least one active plugin. Since gaps and sizes have been removed as plugins, this list is empty. This should fix that!