### PR TITLE
Global mutex lock

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -67,26 +67,26 @@ pipeline {
                         # Do some dry runs to test the DAG
                         # test download workflow
                         printf "\ndownload default\n\n"
-                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --quiet
 
                         # test alignment workflow
                         # default config
                         printf "\nalignment default\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --quiet
 
                         # test aligners
                         printf "\ntesting aligners\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
 
                         # test sorting
                         printf "\ntesting sorting\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --quiet
                         '''
                     },
                     "2 ATAC-seq" : {
@@ -98,19 +98,19 @@ pipeline {
                         # test atac-seq workflow
                         # default config
                         printf "\ndefault atac-seq\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --quiet
 
                         # test different peak callers
                         printf "\natac peakcaller\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --quiet
 
                         # test different replicate settings
                         printf "\natac combine replicates\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv --quiet
                         '''
                     },
                     "3 RNA-seq" : {
@@ -122,17 +122,17 @@ pipeline {
                         # test rna-seq workflow
                         # default config
                         printf "\ndefault rna-seq\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --quiet
 
                         # test differential expression analysis
                         printf "\ndifferential expression\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon --quiet
 
                         # test trackhub generation
                         printf "\ntrackhub\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True --quiet
                         '''
                     }
                 )

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -67,26 +67,26 @@ pipeline {
                         # Do some dry runs to test the DAG
                         # test download workflow
                         printf "\ndownload default\n\n"
-                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --quiet
+                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test alignment workflow
                         # default config
                         printf "\nalignment default\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test aligners
                         printf "\ntesting aligners\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test sorting
                         printf "\ntesting sorting\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
                         '''
                     },
                     "2 ATAC-seq" : {
@@ -98,19 +98,19 @@ pipeline {
                         # test atac-seq workflow
                         # default config
                         printf "\ndefault atac-seq\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test different peak callers
                         printf "\natac peakcaller\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test different replicate settings
                         printf "\natac combine replicates\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
                         '''
                     },
                     "3 RNA-seq" : {
@@ -122,17 +122,17 @@ pipeline {
                         # test rna-seq workflow
                         # default config
                         printf "\ndefault rna-seq\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test differential expression analysis
                         printf "\ndifferential expression\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
 
                         # test trackhub generation
                         printf "\ntrackhub\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
                         '''
                     }
                 )

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -67,26 +67,26 @@ pipeline {
                         # Do some dry runs to test the DAG
                         # test download workflow
                         printf "\ndownload default\n\n"
-                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 -quiet
 
                         # test alignment workflow
                         # default config
                         printf "\nalignment default\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --quiet
 
                         # test aligners
                         printf "\ntesting aligners\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bowtie2.yaml --config samples=../../Jenkins/alignment/local_sample.tsv --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/bwa.yaml     --config samples=../../Jenkins/alignment/local_sample.tsv --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/hisat2.yaml  --config samples=../../Jenkins/alignment/local_sample.tsv --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/star.yaml    --config samples=../../Jenkins/alignment/local_sample.tsv --quiet
 
                         # test sorting
                         printf "\ntesting sorting\n\n"
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_coordinate.yaml --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/samtools_queryname.yaml  --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_coordinate.yaml --quiet
+                        snakemake -s workflows/alignment/Snakefile --directory workflows/alignment -n -j 48 --configfile Jenkins/alignment/sambamba_queryname.yaml  --quiet
                         '''
                     },
                     "2 ATAC-seq" : {
@@ -98,19 +98,19 @@ pipeline {
                         # test atac-seq workflow
                         # default config
                         printf "\ndefault atac-seq\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config --quiet
 
                         # test different peak callers
                         printf "\natac peakcaller\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich.yaml       --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/macs2.yaml         --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --configfile Jenkins/atac_seq/genrich_macs2.yaml --quiet
 
                         # test different replicate settings
                         printf "\natac combine replicates\n\n"
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=fisher samples=../../Jenkins/atac_seq/samples.tsv --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=idr    samples=../../Jenkins/atac_seq/samples.tsv --quiet
+                        snakemake -s workflows/atac_seq/Snakefile --directory workflows/atac_seq -n -j 48 --config combine_replicates=merge  samples=../../Jenkins/atac_seq/samples.tsv --quiet
                         '''
                     },
                     "3 RNA-seq" : {
@@ -122,17 +122,17 @@ pipeline {
                         # test rna-seq workflow
                         # default config
                         printf "\ndefault rna-seq\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --config ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --config --quiet
 
                         # test differential expression analysis
                         printf "\ndifferential expression\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=star   --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/deseq2.yaml --config samples=../../Jenkins/rna_seq/samples.tsv quantifier=salmon --quiet
 
                         # test trackhub generation
                         printf "\ntrackhub\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True ncbi_key=8d516bfc05a769280a23d8a2c0e08f94a708 --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=star   create_trackhub=True --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --configfile Jenkins/rna_seq/counts.yaml --config samples=../../Jenkins/alignment/local_sample.tsv quantifier=salmon create_trackhub=True --quiet
                         '''
                     }
                 )

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -176,7 +176,6 @@ pipeline {
                 printf "\ndownload SE and PE fastqs\n\n"
                 snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq \
                 --use-conda -j $CORES --config samples=../../Jenkins/download_fastq/samples.tsv \
-                --resources parallel_downloads=1
 
                 # test genome & annotation downloading
                 printf "\ndownload genome & annotation\n\n"

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                         # Do some dry runs to test the DAG
                         # test download workflow
                         printf "\ndownload default\n\n"
-                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 -quiet
+                        snakemake -s workflows/download_fastq/Snakefile --directory workflows/download_fastq -n -j 48 --quiet
 
                         # test alignment workflow
                         # default config
@@ -125,7 +125,7 @@ pipeline {
                         # test rna-seq workflow
                         # default config
                         printf "\ndefault rna-seq\n\n"
-                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --config --quiet
+                        snakemake -s workflows/rna_seq/Snakefile --directory workflows/rna_seq -n -j 48 --quiet
 
                         # test differential expression analysis
                         printf "\ndifferential expression\n\n"

--- a/envs/get_fastq.yaml
+++ b/envs/get_fastq.yaml
@@ -5,6 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::parallel-fastq-dump=0.6.5
-  - bioconda::sra-tools=2.9.1
-  - bioconda::entrez-direct=11.0
   - pkgs/main::pigz=2.4

--- a/envs/snakemake-workflows.yaml
+++ b/envs/snakemake-workflows.yaml
@@ -15,5 +15,6 @@ dependencies:
   - pkgs/main::conda=4.7.11
   - bioconda::norns=0.1.5
   - anaconda::biopython=1.74
+  - pkgs/main::filelock=3.0.12
   - pip:
     - git+https://github.com/daler/trackhub@params-overhaul

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -193,8 +193,8 @@ for key, value in config.items():
 
 # check if a sample is single-end or paired end, and store it
 logger.info("Checking if samples are single-end or paired-end...")
-layout_cachefile = './.snakemake/layouts.p'
-layout_cachefile_lock = './.snakemake/layouts.p.lock'
+layout_cachefile = os.path.expanduser('~/.config/snakemake/layouts.p')
+layout_cachefile_lock = os.path.expanduser('~/.config/snakemake/layouts.p.lock')
 
 def get_layout_eutils(sample):
     """
@@ -257,6 +257,11 @@ def get_layout_trace(sample):
 
 # do this locked to avoid parallel ncbi requests with the same key, and to avoid
 # multiple writes/reads at the sametime to layouts.p
+
+# let's ignore locks that are older than 5 minutes
+if os.stat(layout_cachefile_lock).st_mtime > 5 * 60:
+    os.remove(layout_cachefile_lock)
+
 with FileLock(layout_cachefile_lock):
     # try to load the layout cache, otherwise defaults to empty dictionary
     try:

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -255,59 +255,54 @@ def get_layout_trace(sample):
         pass
     return None
 
-
-# try to load the layout cache, otherwise defaults to empty dictionary
+# do this locked to avoid parallel ncbi requests with the same key, and to avoid
+# multiple writes/reads at the sametime to layouts.p
 with FileLock(layout_cachefile_lock):
+    # try to load the layout cache, otherwise defaults to empty dictionary
     try:
         layout_cache = pickle.load(open(layout_cachefile, "rb"))
     except FileNotFoundError:
         layout_cache = {}
 
 
-trace_tp = ThreadPool(20)
-eutils_tp = ThreadPool(config.get('ncbi_requests', 3) // 2)
+    trace_tp = ThreadPool(20)
+    eutils_tp = ThreadPool(config.get('ncbi_requests', 3) // 2)
 
-trace_layout = {}
-config['layout'] = {}
+    trace_layout = {}
+    config['layout'] = {}
 
-# now do a request for each sample that was not in the cache
-for sample in [sample for sample in samples.index if sample not in layout_cache]:
-    config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
-    if os.path.exists(expand(f'{{fastq_dir}}/{sample}.{{fqsuffix}}.gz', **config)[0]):
-        config['layout'][sample] ='SINGLE'
-    elif all(os.path.exists(path) for path in expand(f'{{fastq_dir}}/{sample}_{{fqext}}.{{fqsuffix}}.gz', **config)):
-        config['layout'][sample] ='PAIRED'
-    elif sample.startswith(('GSM', 'SRR', 'ERR', 'DRR')):
-        # config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
-        trace_layout[sample] = trace_tp.apply_async(get_layout_trace, (sample,))
+    # now do a request for each sample that was not in the cache
+    for sample in [sample for sample in samples.index if sample not in layout_cache]:
+        config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
+        if os.path.exists(expand(f'{{fastq_dir}}/{sample}.{{fqsuffix}}.gz', **config)[0]):
+            config['layout'][sample] ='SINGLE'
+        elif all(os.path.exists(path) for path in expand(f'{{fastq_dir}}/{sample}_{{fqext}}.{{fqsuffix}}.gz', **config)):
+            config['layout'][sample] ='PAIRED'
+        elif sample.startswith(('GSM', 'SRR', 'ERR', 'DRR')):
+            # config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
+            trace_layout[sample] = trace_tp.apply_async(get_layout_trace, (sample,))
 
-        # sleep 1.25 times the minimum required sleep time so eutils don't complain
-        time.sleep(1.25 / (config.get('ncbi_requests', 3) // 2))
-    else:
-        raise ValueError(f"\nsample {sample} was not found..\n"
-                         f"We checked for SE file:\n"
-                         f"\t{config['fastq_dir']}/{sample}.{config['fqsuffix']}.gz \n"
-                         f"and for PE files:\n"
-                         f"\t{config['fastq_dir']}/{sample}_{config['fqext1']}.{config['fqsuffix']}.gz \n"
-                         f"\t{config['fastq_dir']}/{sample}_{config['fqext2']}.{config['fqsuffix']}.gz \n"
-                         f"and since the sample did not start with either GSM, SRR, ERR, and DRR we couldn't find it online..\n")
-
-# now parse the output and store the cache, the local files' layout, and the ones that were fetched online
-config['layout'] = {**layout_cache,
-                    **{k: (v if isinstance(v, str) else v.get()) for k, v in config['layout'].items()},
-                    **{k: v.get() for k, v in trace_layout.items() if v.get() is not None}}
-
-assert all(layout in ['SINGLE', 'PAIRED'] for sample, layout in config['layout'].items())
-
-# if new samples were added, update the cache
-if len([sample for sample in samples.index if sample not in layout_cache]) is not 0:
-    with FileLock(layout_cachefile_lock):
-        # if the layour cache exists, it might've been updated so make sure to use the most recent version
-        if os.path.exists(layout_cachefile):
-            layout_cache_recent = pickle.load(open(layout_cachefile, "rb"))
-            pickle.dump({**layout_cache_recent, **config['layout']}, open(layout_cachefile, "wb"))
+            # sleep 1.25 times the minimum required sleep time so eutils don't complain
+            time.sleep(1.25 / (config.get('ncbi_requests', 3) // 2))
         else:
-            pickle.dump({**config['layout']}, open(layout_cachefile, "wb"))
+            raise ValueError(f"\nsample {sample} was not found..\n"
+                             f"We checked for SE file:\n"
+                             f"\t{config['fastq_dir']}/{sample}.{config['fqsuffix']}.gz \n"
+                             f"and for PE files:\n"
+                             f"\t{config['fastq_dir']}/{sample}_{config['fqext1']}.{config['fqsuffix']}.gz \n"
+                             f"\t{config['fastq_dir']}/{sample}_{config['fqext2']}.{config['fqsuffix']}.gz \n"
+                             f"and since the sample did not start with either GSM, SRR, ERR, and DRR we couldn't find it online..\n")
+
+    # now parse the output and store the cache, the local files' layout, and the ones that were fetched online
+    config['layout'] = {**layout_cache,
+                        **{k: (v if isinstance(v, str) else v.get()) for k, v in config['layout'].items()},
+                        **{k: v.get() for k, v in trace_layout.items() if v.get() is not None}}
+
+    assert all(layout in ['SINGLE', 'PAIRED'] for sample, layout in config['layout'].items())
+
+    # if new samples were added, update the cache
+    if len([sample for sample in samples.index if sample not in layout_cache]) is not 0:
+        pickle.dump({**config['layout']}, open(layout_cachefile, "wb"))
 
 # now only keep the layout of samples that are in samples.tsv
 config['layout'] = {key: value for key, value in config['layout'].items() if key in samples.index}

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -379,7 +379,7 @@ def convert_size(size_bytes, order=None):
 
 
 # by default only one download in parallel (workflow fails on multiple on a single node)
-workflow.global_resources = {**{'parallel_downloads': 1, 'deeptools_limit': 1, 'R_scripts': 1},
+workflow.global_resources = {**{'parallel_downloads': 3, 'deeptools_limit': 1, 'R_scripts': 1},
                              **workflow.global_resources}
 
 # when the user specifies memory, use this and give a warning if it surpasses local memory

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -257,6 +257,9 @@ def get_layout_trace(sample):
 
 # do this locked to avoid parallel ncbi requests with the same key, and to avoid
 # multiple writes/reads at the sametime to layouts.p
+if not os.path.exists(os.path.dirname(layout_cachefile_lock)):
+    os.makedirs(os.path.dirname(layout_cachefile_lock))
+
 # let's ignore locks that are older than 5 minutes
 if os.path.exists(layout_cachefile_lock) and \
         time.time() - os.stat(layout_cachefile_lock).st_mtime > 5 * 60:

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -259,7 +259,7 @@ def get_layout_trace(sample):
 # multiple writes/reads at the sametime to layouts.p
 
 # let's ignore locks that are older than 5 minutes
-if os.exists(layout_cachefile_lock) and \
+if os.path.exists(layout_cachefile_lock) and \
         time.time() - os.stat(layout_cachefile_lock).st_mtime > 5 * 60:
     os.remove(layout_cachefile_lock)
 

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -259,7 +259,8 @@ def get_layout_trace(sample):
 # multiple writes/reads at the sametime to layouts.p
 
 # let's ignore locks that are older than 5 minutes
-if os.stat(layout_cachefile_lock).st_mtime > 5 * 60:
+if os.exists(layout_cachefile_lock) and \
+        time.time() - os.stat(layout_cachefile_lock).st_mtime > 5 * 60:
     os.remove(layout_cachefile_lock)
 
 with FileLock(layout_cachefile_lock):

--- a/rules/get_fastq.smk
+++ b/rules/get_fastq.smk
@@ -41,36 +41,36 @@ rule id2sra:
                 declare -a URLS
                 for ID in $IDS;
                 do
-                    sleep 3s;
+                    sleep 2s;
                     WGET_URL=$(esearch -db sra -query $ID | efetch --format runinfo | grep $ID | cut -d ',' -f 10 | grep http);
                     URLS+=($WGET_URL);
                 done;
 
                 mkdir {output}
+                printf '%s\n' "${{IDS[@]}}" > {output}/ids
+                printf '%s\n' "${{URLS[@]}}" > {output}/urls
                 echo $TYPE_L > {output}/type_l
                 echo $TYPE_U > {output}/type_u
-                echo $IDS > {output}/ids
-                echo $URLS > {output}/urls            
                 """)
-            time.sleep(3)
+            time.sleep(2)
 
         shell(
             """
             read TYPE_L < {output}/type_l
             read TYPE_U < {output}/type_u
-            read IDS < {output}/ids
-            read URLS < {output}/urls
+            readarray -t IDS < {output}/ids
+            readarray -t URLS < {output}/urls
             rm {output}/*
-            index=0
-            for ID in $IDS;
-            do
+            for i in ${{!IDS[@]}}; do
+                ID="${{IDS[i]}}"
+
                 PREFIX=$(echo $ID | cut -c1-6);
                 SUFFIX=$(echo -n $ID | tail -c 3);
         
                 URL_ENA1="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$SUFFIX/$ID";
                 URL_ENA2="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$ID";
                 URL_NCBI="anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/$TYPE_U/$PREFIX/$ID/$ID.sra";
-                WGET_URL=${{URLS[$index]}}
+                WGET_URL=${{URLS[i]}}
 
                 echo "trying to download $ID from, respectively: \n$URL_ENA1 \n$URL_ENA2 \n$URL_NCBI \n$WGET_URL" >> {log}
                 # first try the ENA (which has at least two different filing systems), if not successful, try NCBI
@@ -79,7 +79,6 @@ rule id2sra:
                 {params.ascp_path} -i {params.ascp_key} -P33001 -T -d -k 0 -Q -l 2G -m 250M $URL_ENA2 {output[0]} >> {log} 2>&1 ||
                 {params.ascp_path} -i {params.ascp_key}         -T -d -k 0 -Q -l 2G -m 250M $URL_NCBI {output[0]} >> {log} 2>&1 ||
                 (mkdir -p {output[0]} >> {log} 2>&1 && wget -O {output[0]}/$ID -a {log} -nv $WGET_URL >> {log} 2>&1)
-                (( index++ ))
             done;
         
             #if the folder contains multiple files, concatenate them

--- a/rules/get_fastq.smk
+++ b/rules/get_fastq.smk
@@ -24,47 +24,49 @@ rule id2sra:
     params:
         ascp_path=config.get('ascp_path', "NO_ASCP_PATH_PROVIDED"),
         ascp_key= config.get('ascp_key', "NO_ASCP_key_PROVIDED")
-    shell:
-        """
-        echo "starting lookup of the sample in the sra database:" > {log}
-        if [[ {wildcards.sample} =~ GSM ]]; then
-            IDS=$(esearch -db sra -query {wildcards.sample} | efetch --format runinfo | cut -d ',' -f 1 | grep SRR);
-            TYPE_U=SRR;
-        else
-            IDS={wildcards.sample};
-            TYPE_U=$(echo {wildcards.sample} | grep 'SRR|ERR|DRR' -E -o);
-        fi;
-        TYPE_L=$(echo $TYPE_U | tr '[:upper:]' '[:lower:]');
-        echo "ids: $IDS, type (uppercase): $TYPE_U, type (lowercase): $TYPE_L" >> {log}
-
-        for ID in $IDS;
-        do
-            PREFIX=$(echo $ID | cut -c1-6);
-            SUFFIX=$(echo -n $ID | tail -c 3);
-
-            URL_ENA1="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$SUFFIX/$ID";
-            URL_ENA2="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$ID";
-            URL_NCBI="anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/$TYPE_U/$PREFIX/$ID/$ID.sra";
-            WGET_URL=$(esearch -db sra -query $ID | efetch --format runinfo | grep $ID | cut -d ',' -f 10 | grep http);
-
-            echo "trying to download $ID from, respectively: \n$URL_ENA1 \n$URL_ENA2 \n$URL_NCBI \n$WGET_URL" >> {log}
-            # first try the ENA (which has at least two different filing systems), if not successful, try NCBI
-            # if none of the ascp servers work, or ascp is not defined in the config, then simply wget
-            {params.ascp_path} -i {params.ascp_key} -P33001 -T -d -k 0 -Q -l 2G -m 250M $URL_ENA1 {output[0]} >> {log} 2>&1 ||
-            {params.ascp_path} -i {params.ascp_key} -P33001 -T -d -k 0 -Q -l 2G -m 250M $URL_ENA2 {output[0]} >> {log} 2>&1 ||
-            {params.ascp_path} -i {params.ascp_key}         -T -d -k 0 -Q -l 2G -m 250M $URL_NCBI {output[0]} >> {log} 2>&1 ||
-            (mkdir -p {output[0]} >> {log} 2>&1 && wget -O {output[0]}/$ID -a {log} -nv $WGET_URL >> {log} 2>&1)
-        done;
-
-        #if the folder contains multiple files, concatenate them
-        if [[ $(ls -1q {output[0]} | wc -l) > 1 ]]; then
-          catfile={output[0]}/$TYPE_U'_concatenated'
-          for file in {output[0]}/*; do
-            cat $file >> $catfile && rm $file
-          done
-        fi
-        """
-
+    run:
+        with FileLock(layout_cachefile_lock):
+            shell(
+                """
+                echo "starting lookup of the sample in the sra database:" > {log}
+                if [[ {wildcards.sample} =~ GSM ]]; then
+                    IDS=$(esearch -db sra -query {wildcards.sample} | efetch --format runinfo | cut -d ',' -f 1 | grep SRR);
+                    TYPE_U=SRR;
+                else
+                    IDS={wildcards.sample};
+                    TYPE_U=$(echo {wildcards.sample} | grep 'SRR|ERR|DRR' -E -o);
+                fi;
+                TYPE_L=$(echo $TYPE_U | tr '[:upper:]' '[:lower:]');
+                echo "ids: $IDS, type (uppercase): $TYPE_U, type (lowercase): $TYPE_L" >> {log}
+        
+                for ID in $IDS;
+                do
+                    PREFIX=$(echo $ID | cut -c1-6);
+                    SUFFIX=$(echo -n $ID | tail -c 3);
+        
+                    URL_ENA1="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$SUFFIX/$ID";
+                    URL_ENA2="era-fasp@fasp.sra.ebi.ac.uk:/vol1/$TYPE_L/$PREFIX/$ID";
+                    URL_NCBI="anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/$TYPE_U/$PREFIX/$ID/$ID.sra";
+                    WGET_URL=$(esearch -db sra -query $ID | efetch --format runinfo | grep $ID | cut -d ',' -f 10 | grep http);
+        
+                    echo "trying to download $ID from, respectively: \n$URL_ENA1 \n$URL_ENA2 \n$URL_NCBI \n$WGET_URL" >> {log}
+                    # first try the ENA (which has at least two different filing systems), if not successful, try NCBI
+                    # if none of the ascp servers work, or ascp is not defined in the config, then simply wget
+                    {params.ascp_path} -i {params.ascp_key} -P33001 -T -d -k 0 -Q -l 2G -m 250M $URL_ENA1 {output[0]} >> {log} 2>&1 ||
+                    {params.ascp_path} -i {params.ascp_key} -P33001 -T -d -k 0 -Q -l 2G -m 250M $URL_ENA2 {output[0]} >> {log} 2>&1 ||
+                    {params.ascp_path} -i {params.ascp_key}         -T -d -k 0 -Q -l 2G -m 250M $URL_NCBI {output[0]} >> {log} 2>&1 ||
+                    (mkdir -p {output[0]} >> {log} 2>&1 && wget -O {output[0]}/$ID -a {log} -nv $WGET_URL >> {log} 2>&1)
+                done;
+        
+                #if the folder contains multiple files, concatenate them
+                if [[ $(ls -1q {output[0]} | wc -l) > 1 ]]; then
+                  catfile={output[0]}/$TYPE_U'_concatenated'
+                  for file in {output[0]}/*; do
+                    cat $file >> $catfile && rm $file
+                  done
+                fi
+                """
+            )
 
 rule sra2fastq_SE:
     """

--- a/rules/get_fastq.smk
+++ b/rules/get_fastq.smk
@@ -64,7 +64,6 @@ rule id2sra:
             index=0
             for ID in $IDS;
             do
-                echo $ID
                 PREFIX=$(echo $ID | cut -c1-6);
                 SUFFIX=$(echo -n $ID | tail -c 3);
         

--- a/rules/get_fastq.smk
+++ b/rules/get_fastq.smk
@@ -19,8 +19,6 @@ rule id2sra:
         parallel_downloads=1
     wildcard_constraints:
         sample="(GSM|SRR|ERR|DRR)\d+"
-    conda:
-        "../envs/get_fastq.yaml"
     params:
         ascp_path=config.get('ascp_path', "NO_ASCP_PATH_PROVIDED"),
         ascp_key= config.get('ascp_key', "NO_ASCP_key_PROVIDED")


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
layouts.p is now stored in .config/snakemake.layouts.p. The filelock is now "global", in the sense that each user has a layouts and a lock around it. If people were to use ncbi keys on e.g. mb07, they should (?) never interfere with each other.

Since we have a global filelock we can re-use this for our id2sra rule, which means that the downloading can now we done in parallel!! (I set the default to 3)

Note that in the tests the downloading also happens in parallel :)