### PR TITLE
allow for comments in samples.tsv

### DIFF
--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -50,7 +50,7 @@ assert sorted(config['fqext'])[0] == config['fqext1'], \
      f"Your suffixes:    fqext1: {config['fqext1']}, fqext2: {config['fqext2']}\n")
 
 # read and sanitize the samples file
-samples = pd.read_csv(config["samples"], sep='\t', dtype='str')
+samples = pd.read_csv(config["samples"], sep='\t', dtype='str', comment='#')
 
 # sanitize column names
 samples.columns = samples.columns.str.strip()

--- a/workflows/alignment/samples.tsv
+++ b/workflows/alignment/samples.tsv
@@ -1,3 +1,6 @@
+# for help with filling out the samples.tsv:
+# https://github.com/vanheeringen-lab/snakemake-workflows/wiki/1.1-Filling-out-the-samples.tsv
+# also make sure that you use tab as a delimiter
 sample	assembly
 GSM2520641	Spur_4.2
 GSM2837484	Bl71nemr

--- a/workflows/atac_seq/samples.tsv
+++ b/workflows/atac_seq/samples.tsv
@@ -1,3 +1,6 @@
+# for help with filling out the samples.tsv:
+# https://github.com/vanheeringen-lab/snakemake-workflows/wiki/1.1-Filling-out-the-samples.tsv
+# also make sure that you use tab as a delimiter
 sample	assembly	condition	descriptive_name
 GSM2837488	Bl71nemr	adult	adult_1
 GSM2837489	Bl71nemr	adult	adult_2

--- a/workflows/chip_seq/samples.tsv
+++ b/workflows/chip_seq/samples.tsv
@@ -1,2 +1,5 @@
+# for help with filling out the samples.tsv:
+# https://github.com/vanheeringen-lab/snakemake-workflows/wiki/1.1-Filling-out-the-samples.tsv
+# also make sure that you use tab as a delimiter
 sample	assembly	descriptive_name
 GSM4404624	GRCh38.p13	HEL_cell

--- a/workflows/download_fastq/samples.tsv
+++ b/workflows/download_fastq/samples.tsv
@@ -1,3 +1,6 @@
+# for help with filling out the samples.tsv:
+# https://github.com/vanheeringen-lab/snakemake-workflows/wiki/1.1-Filling-out-the-samples.tsv
+# also make sure that you use tab as a delimiter
 sample
 GSM2520641
 GSM2520642

--- a/workflows/rna_seq/samples.tsv
+++ b/workflows/rna_seq/samples.tsv
@@ -1,3 +1,6 @@
+# for help with filling out the samples.tsv:
+# https://github.com/vanheeringen-lab/snakemake-workflows/wiki/1.1-Filling-out-the-samples.tsv
+# also make sure that you use tab as a delimiter
 sample	assembly	stages	descriptive_name
 GSM1483769	GRCz11	1	1360_mpf
 GSM1483770	GRCz11	2	1400_mpf


### PR DESCRIPTION
The `samples.tsv` now has a little comment pointing to our docs, and a reminder to use tabs as a delimiter.