### PR TITLE
seq2science command line interface

### DIFF
--- a/bin/seq2science
+++ b/bin/seq2science
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+import sys
+import argparse
+import os
+import shutil
+import json
+import webbrowser
+
+from snakemake import snakemake
+
+
+__version__ = "0.0.0"
+
+
+def main():
+    # set helpful paths
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    workflows_dir = os.path.join(base_dir, "workflows")
+    cwd = os.getcwd()
+
+    # setup the parser
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    init = subparsers.add_parser(
+        "init",
+        description="Initialise the workflow with an example config and samples file.",
+        help="Initialise the workflow with an example config and samples file.",
+    )
+    run = subparsers.add_parser(
+        "run", description="Run the complete workflow.", help="Run a complete workflow."
+    )
+    docs = subparsers.add_parser(
+        "docs", description="Take me to the docs (description).", help="Take me to the docs (help)."
+    )
+
+    for subparser in [init, run]:
+        subparser.add_argument("-c", "--config", default="config.yaml")
+        subparser.add_argument("workflow", choices=os.listdir(workflows_dir))
+
+    # allow users to provide virtually any snakemake arguments
+    run.add_argument("--kwargs", nargs="+", action=_StoreDictKeyPair, metavar="KEY=VAL")
+    args = parser.parse_args()
+
+    # turn all paths into absolute paths
+    config_path = args.config
+    if not os.path.isabs(args.config):
+        config_path = os.path.join(os.getcwd(), args.config)
+
+    if args.command == "init":
+        _init(args, cwd, workflows_dir)
+    elif args.command == "run":
+        _run(args, workflows_dir, config_path)
+    elif args.command == "docs":
+        _docs()
+
+
+def _init(args, cwd, workflows_dir):
+    """
+    The init function...
+    """
+    for file in ["samples.tsv", "config.yaml"]:
+        src = os.path.join(workflows_dir, args.workflow, file)
+        dest = os.path.join(cwd, file)
+        copy_file = True
+        if os.path.exists(dest):
+            choices = {"yes": True, "y": True, "no": False, "n": False}
+
+            sys.stdout.write("do you want to overtwtie?")
+            while True:
+                choice = input().lower()
+                if choice in choices:
+                    copy_file = choices[choice]
+                    break
+                else:
+                    sys.stdout.write("Please respond with yes (y) or no (n).")
+
+        if copy_file:
+            shutil.copyfile(
+                os.path.join(workflows_dir, args.workflow, file),
+                os.path.join(cwd, file),
+            )
+    sys.exit(0)
+
+
+def _run(args, workflows_dir, config_path):
+    """
+    The run function...
+    """
+    if not os.path.exists(config_path):
+        sys.stdout.write(
+            f"The config file: {config_path} does not exist.\nProvide a path to the config file with "
+            f"--config or if you do not have a config file run:\n"
+            f"seq2science init {args.workflow}\n"
+        )
+        sys.exit(1)
+
+    exit_code = snakemake(
+        snakefile=os.path.join(workflows_dir, args.workflow, "Snakefile"),
+        configfiles=[config_path],
+    )
+    sys.exit(exit_code)
+
+
+def _docs():
+    url = "https://github.com/vanheeringen-lab/snakemake-workflows/wiki"
+    if not webbrowser.open(url):
+        print(url)
+
+
+class _StoreDictKeyPair(argparse.Action):
+    """
+    Solution taken from:
+    https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
+    """
+
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        self._nargs = nargs
+        super(_StoreDictKeyPair, self).__init__(
+            option_strings, dest, nargs=nargs, **kwargs
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        my_dict = {}
+        for kv in values:
+            k, v = kv.split("=")
+            my_dict[k] = v
+        setattr(namespace, self.dest, my_dict)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/seq2science
+++ b/bin/seq2science
@@ -16,75 +16,118 @@ def main():
     # set helpful paths
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     workflows_dir = os.path.join(base_dir, "workflows")
-    cwd = os.getcwd()
 
-    # setup the parser
-    parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest="command")
-    init = subparsers.add_parser(
-        "init",
-        description="Initialise the workflow with an example config and samples file.",
-        help="Initialise the workflow with an example config and samples file.",
-    )
-    run = subparsers.add_parser(
-        "run", description="Run the complete workflow.", help="Run a complete workflow."
-    )
-    docs = subparsers.add_parser(
-        "docs", description="Take me to the docs (description).", help="Take me to the docs (help)."
-    )
-
-    for subparser in [init, run]:
-        subparser.add_argument("-c", "--config", default="config.yaml")
-        subparser.add_argument("workflow", choices=os.listdir(workflows_dir))
-
-    # allow users to provide virtually any snakemake arguments
-    run.add_argument("--kwargs", nargs="+", action=_StoreDictKeyPair, metavar="KEY=VAL")
+    parser = seq2science_parser(workflows_dir)
     args = parser.parse_args()
 
-    # turn all paths into absolute paths
-    config_path = args.config
-    if not os.path.isabs(args.config):
-        config_path = os.path.join(os.getcwd(), args.config)
+    # turn config path into absolute path
+    if args.command in ["init", "run"]:
+        config_path = args.config
+        if not os.path.isabs(args.config):
+            config_path = os.path.join(os.getcwd(), args.config)
 
+    # now run the command
     if args.command == "init":
-        _init(args, cwd, workflows_dir)
+        _init(args, workflows_dir, config_path)
     elif args.command == "run":
         _run(args, workflows_dir, config_path)
     elif args.command == "docs":
         _docs()
 
 
-def _init(args, cwd, workflows_dir):
+def seq2science_parser(workflows_dir):
     """
-    The init function...
+    Make the seq2science parser.
+    """
+    # setup the parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"seq2science: v{__version__}"
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+    init = subparsers.add_parser(
+        "init",
+        description="Each workflow requires a configuration and samples file to run. "
+        'Running "seq2science init {workflow}" initialises a default '
+        "configuration and samples file for the specific workflow.",
+        help="Initialise a workflow with an example config and samples file.",
+    )
+    run = subparsers.add_parser(
+        "run",
+        description="Run a complete workflow. This requires that a config and samples file "
+        "are present. These files can be ",
+        help="Run a complete workflow.",
+    )
+    docs = subparsers.add_parser(
+        "docs",
+        description="The docs command tries to open your browser and open the docs' webpage, "
+        "if that didn't work it prints the url.",
+        help="Take me to the docs!",
+    )
+
+    for subparser in [init, run]:
+        subparser.add_argument(
+            "-c",
+            "--config",
+            default="config.yaml",
+            metavar="FILE",
+            help="The path to the config file.",
+        )
+        subparser.add_argument("workflow", choices=os.listdir(workflows_dir))
+
+    # allow users to provide virtually any snakemake arguments
+    run.add_argument(
+        "--cores",
+        required=True,
+        metavar="N",
+        type=int,
+        help="Use at most N cores in parallel.",
+    )
+    # TODO: how to call kwargs?
+    run.add_argument(
+        "--kwargs",
+        nargs="+",
+        action=_StoreDictKeyPair,
+        metavar="KEY=VAL",
+        help="Extra arguments to pass along to snakemake. An example could be seq2science run "
+        "{workflow} --cores 10 --kwargs dryrun=True. Take a look at the snakemake API for a "
+        "list of all possible options: https://snakemake.readthedocs.io/en/latest/api_reference/snakemake.html",
+    )
+
+    return parser
+
+
+def _init(args, workflows_dir, config_path):
+    """
+    Initialise a config.yaml and samples.tsv from the relevant workflow.
     """
     for file in ["samples.tsv", "config.yaml"]:
         src = os.path.join(workflows_dir, args.workflow, file)
-        dest = os.path.join(cwd, file)
+        dest = os.path.join(os.path.dirname(config_path), file)
+
         copy_file = True
         if os.path.exists(dest):
             choices = {"yes": True, "y": True, "no": False, "n": False}
 
-            sys.stdout.write("do you want to overtwtie?")
+            sys.stdout.write(
+                f"File: {dest} already exists. Do you want to overwrite it? (yes/no) "
+            )
             while True:
                 choice = input().lower()
                 if choice in choices:
                     copy_file = choices[choice]
                     break
                 else:
-                    sys.stdout.write("Please respond with yes (y) or no (n).")
+                    print("Please respond with yes (y) or no (n).")
 
         if copy_file:
-            shutil.copyfile(
-                os.path.join(workflows_dir, args.workflow, file),
-                os.path.join(cwd, file),
-            )
-    sys.exit(0)
+            shutil.copyfile(src, dest)
 
 
 def _run(args, workflows_dir, config_path):
     """
-    The run function...
+    Run a complete workflow.
     """
     if not os.path.exists(config_path):
         sys.stdout.write(
@@ -102,6 +145,9 @@ def _run(args, workflows_dir, config_path):
 
 
 def _docs():
+    """
+    Open a webbrowser to the docs, if that fails simply print the url.
+    """
     url = "https://github.com/vanheeringen-lab/snakemake-workflows/wiki"
     if not webbrowser.open(url):
         print(url)
@@ -109,7 +155,8 @@ def _docs():
 
 class _StoreDictKeyPair(argparse.Action):
     """
-    Solution taken from:
+    Class that allows us to take key=value pairs from command-line to feed to
+    snakemake. Solution taken from:
     https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
     """
 

--- a/bin/seq2science
+++ b/bin/seq2science
@@ -5,6 +5,7 @@ import os
 import shutil
 import json
 import webbrowser
+import re
 
 from snakemake import snakemake
 
@@ -30,7 +31,7 @@ def main():
     if args.command == "init":
         _init(args, workflows_dir, config_path)
     elif args.command == "run":
-        _run(args, workflows_dir, config_path)
+        _run(args, base_dir, workflows_dir, config_path)
     elif args.command == "docs":
         _docs()
 
@@ -66,32 +67,56 @@ def seq2science_parser(workflows_dir):
         help="Take me to the docs!",
     )
 
+    # both init and run can use all workflows
     for subparser in [init, run]:
-        subparser.add_argument(
-            "-c",
-            "--config",
-            default="config.yaml",
-            metavar="FILE",
-            help="The path to the config file.",
-        )
         subparser.add_argument("workflow", choices=os.listdir(workflows_dir))
 
-    # allow users to provide virtually any snakemake arguments
+    # setup init arguments
+    init.add_argument(
+        "--dir",
+        default=".",
+        metavar="PATH",
+        help="The path to the directory where to initialise the config and samples files.",
+    )
+
+    # setup run arguments
+    def minimum_cores(value):
+        ivalue = int(value)
+        if ivalue < 2:
+            raise argparse.ArgumentTypeError(f"Please provide 2 or more cores.")
+        return ivalue
+
+    run.add_argument(
+        "-c",
+        "--config",
+        default="config.yaml",
+        metavar="FILE",
+        help="The path to the config file.",
+    )
     run.add_argument(
         "--cores",
         required=True,
         metavar="N",
-        type=int,
+        type=minimum_cores,
         help="Use at most N cores in parallel.",
     )
-    # TODO: how to call kwargs?
     run.add_argument(
-        "--kwargs",
+        "-n", "--dryrun",
+        help="Do not execute anything, and display what would be done.",
+        action='store_true'
+    )
+    run.add_argument(
+        "--unlock",
+        help="Remove a lock on the working directory.",
+        action='store_true'
+    )
+    run.add_argument(
+        "--snakemakeOptions",
         nargs="+",
         action=_StoreDictKeyPair,
         metavar="KEY=VAL",
         help="Extra arguments to pass along to snakemake. An example could be seq2science run "
-        "{workflow} --cores 10 --kwargs dryrun=True. Take a look at the snakemake API for a "
+        "{workflow} --cores 10 --snakemakeOptions resources={mem_gb:100} local_cores=3. Take a look at the snakemake API for a "
         "list of all possible options: https://snakemake.readthedocs.io/en/latest/api_reference/snakemake.html",
     )
 
@@ -125,7 +150,7 @@ def _init(args, workflows_dir, config_path):
             shutil.copyfile(src, dest)
 
 
-def _run(args, workflows_dir, config_path):
+def _run(args, base_dir, workflows_dir, config_path):
     """
     Run a complete workflow.
     """
@@ -140,6 +165,12 @@ def _run(args, workflows_dir, config_path):
     exit_code = snakemake(
         snakefile=os.path.join(workflows_dir, args.workflow, "Snakefile"),
         configfiles=[config_path],
+        config={"rule_dir": os.path.join(base_dir, "rules")},
+        cores=args.cores,
+        use_conda=True,
+        conda_prefix=base_dir,
+        dryrun=args.dryrun,
+        **args.snakemakeOptions
     )
     sys.exit(exit_code)
 
@@ -170,7 +201,16 @@ class _StoreDictKeyPair(argparse.Action):
         my_dict = {}
         for kv in values:
             k, v = kv.split("=")
-            my_dict[k] = v
+            if v[0] == "{" and v[-1] == "}":
+                pairs = list(filter(None, re.split('{|:| |}', v)))
+                assert len(pairs) % 2 == 0
+                v = {pairs[i]: pairs[i+1] for i in range(0, len(pairs), 2)}
+                v = {k: int(v) if v.isdigit() else v for k, v in v.items()}
+            try:
+                my_dict[k] = int(v)
+            except:
+                my_dict[k] = v
+
         setattr(namespace, self.dest, my_dict)
 
 

--- a/bin/seq2science
+++ b/bin/seq2science
@@ -168,7 +168,7 @@ def _run(args, base_dir, workflows_dir, config_path):
         config={"rule_dir": os.path.join(base_dir, "rules")},
         cores=args.cores,
         use_conda=True,
-        conda_prefix=base_dir,
+        conda_prefix=os.path.join(base_dir, ".snakemake"),
         dryrun=args.dryrun,
         **args.snakemakeOptions
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "seq2science"
+version = "0.0.0"
+description = "seq2science: preprocessing of ngs data."
+author = [
+    "Maarten van der Sande <M.vanderSande@science.ru.nl>"]
+license = "MIT"
+url = "https://vanheeringen-lab.github.io/snakemake-workflows"
+scripts = ["scripts/seq2science"]
+package_data = "{'seq2science':['*']}"
+include_package_data = true
+
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Bio-Informatics"]
+
+install_requires = ["snakemake", "toml"]
+python_requires = ">3.6"
+
+[build-system]
+requires = ["setuptools", "wheel", "toml"]
+build-backend = "setuptools.build_meta"
+
+# flake8 does not support pyproject.toml (yet?!)
+# [flake8] ...

--- a/scripts/seq2science
+++ b/scripts/seq2science
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""
+This is the user's entry-point for the seq2science pipeline.
+"""
 import sys
 import argparse
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+import ast
+import toml
+
+project = toml.load("pyproject.toml")["project"]
+
+# read the readme as long description
+with open("README.md") as f:
+    project["long_description"] = f.read()
+
+project["long_description_content_type"] = "text/markdown"
+project["package_data"] = ast.literal_eval(project["package_data"])
+import sys
+sys.stdout.write("\n\n\n\n")
+sys.stdout.write(str(project))
+sys.stdout.write("\n\n\n\n")
+# find packages to install
+# project["packages"] = find_packages(where='./*', exclude=())
+# # print()
+# assert False, project["packages"]
+
+setup(**project)


### PR DESCRIPTION
Start on seq2science migration with CLI. I decided to make a seq2science branch to keep the migration separate from the normal development.

@siebrenf can you take a look if this is what you had in mind for a cli? I implemented three subcommands: init, run and docs. 
```
usage: seq2science [-h] [-v] {init,run,docs} ...

positional arguments:
  {init,run,docs}
    init           Initialise a workflow with an example config and samples
                   file.
    run            Run a complete workflow.
    docs           Take me to the docs!

optional arguments:
  -h, --help       show this help message and exit
  -v, --version    show program's version number and exit
```

### init 
Makes a config.yaml and samples.tsv for a specific workflow:
```
usage: seq2science init [-h] [-c FILE]
                        {chip_seq,alignment,scATAC_seq,download_fastq,rna_seq,scRNA_seq,atac_seq}

Each workflow requires a configuration and samples file to run. Running
"seq2science init {workflow}" initialises a default configuration and samples
file for the specific workflow.

positional arguments:
  {chip_seq,alignment,scATAC_seq,download_fastq,rna_seq,scRNA_seq,atac_seq}

optional arguments:
  -h, --help            show this help message and exit
  -c FILE, --config FILE
                        The path to the config file.
```

### run
Run a workflow:
```
usage: seq2science run [-h] [-c FILE] --cores N
                       [--kwargs KEY=VAL [KEY=VAL ...]]
                       {chip_seq,alignment,scATAC_seq,download_fastq,rna_seq,scRNA_seq,atac_seq}

Run a complete workflow. This requires that a config and samples file are
present. These files can be

positional arguments:
  {chip_seq,alignment,scATAC_seq,download_fastq,rna_seq,scRNA_seq,atac_seq}

optional arguments:
  -h, --help            show this help message and exit
  -c FILE, --config FILE
                        The path to the config file.
  --cores N             Use at most N cores in parallel.
  --kwargs KEY=VAL [KEY=VAL ...]
                        Extra arguments to pass along to snakemake. An example
                        could be seq2science run {workflow} --cores 10
                        --kwargs dryrun=True. Take a look at the snakemake API
                        for a list of all possible options: https://snakemake.
                        readthedocs.io/en/latest/api_reference/snakemake.html
```

### docs
Just some fluff, open a link to the docs, if that doesn't work print the url.

